### PR TITLE
Make two step process optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,17 +47,19 @@ good indication that the RFC is worth pursuing.
 
 [what the process is]: #what-the-process-is
 
-In short, to get a major feature added to Linkerd, one must first get the RFC merged into the RFC `problem/` directory as a markdown file.
+To get a major feature added to Linkerd, one must get the RFC merged into the RFC repository in either one or two steps.
 
-Once the feature is accepted and one is interested in the design, the markdown file should be moved into the `design/` directory.
+First, the problem statement should be completed. If one does not intend to design or implement the RFC, then the proposal can be merged as is after going through reviews.
 
-At that point, the RFC is "active" and may be implemented with the goal of eventual inclusion into Linkerd.
+Second, the design proposal is completed. Once the design is accepted, the RFC is considered active and may be implemented with the goal of eventual inclusion into Linkerd.
+
+If one intends to state the problem and propose a design, then both sections can be completed in a single review.
 
 ### Step 1
 1. Fork the [RFC repository](https://github.com/linkerd/rfc)
 2. Copy `0000-rfc-template.md` to `problem/0000-my-contribution.md` (where "my-contribution" is descriptive.).
-3. Fill in the RFC, leaving the `Design proposal` section for `Step 2`.
-4. Submit a pull request. As a pull request `Problem statement` will receive feedback from the larger community, and the author should be prepared to revise it in response.
+3. Fill in the RFC. Leave `Design Proposal` section for `Step 2` if you do not intend to propose a design, or would like to first gather feedback on the problem.
+4. If completing RFC in separate steps, submit a pull request. As a pull request `Problem statement` will receive feedback from the larger community, and the author should be prepared to revise it in response.
 
 ### Step 2
 1. Move `problem/0000-my-contribution.md` to `design/0000-my-contribution.md`.
@@ -65,6 +67,7 @@ At that point, the RFC is "active" and may be implemented with the goal of event
 3. Submit a pull request. As a pull request `Design proposal` will receive feedback from the larger community, and the author should be prepared to revise it in response.
 
 ### Note
+- If you have not already gathered feedback on the problem, it is advised to complete the process in two steps; it is better to ensure the problem needs to be solved before spending time on the design.
 - Each pull request will be labeled with the most relevant reviewer, who will lead its triage.
 - Build consensus and integrate feedback. RFCs that have broad support are much more likely to make progress than those that don't receive any comments. Feel free to reach out to the RFC assignee in particular to get help identifying stakeholders and obstacles.
 - The team will discuss the RFC pull request, as much as possible in the comment thread of the pull request itself. Offline discussion will be summarized on the pull request comment thread.


### PR DESCRIPTION
Requiring two steps for merging an RFC can add a lot of process if the problem
statement and design have already been thoroughly discussed.

This updates the RFC process to make the two step separation optional.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>