### PR TITLE
Bring your own prometheus

### DIFF
--- a/design/0003-byop.md
+++ b/design/0003-byop.md
@@ -162,8 +162,12 @@ have the relevant scrape-configs and default configuration.
 [prior-art]: #prior-art
 
 - [Prometheus  Operator](https://github.com/coreos/prometheus-operator) is a interesting tool,
- which can remove the problem of maintaining configuration for upgrades, etc from Linkerd, 
+ which can remove the problem of maintaining configuration for upgrades, etc from Linkerd,
  but comes with it's own controller and CRD's.
+- Specific to resource costs, We can consider things like tuning prometheus, dropping labels, etc making it
+  further lighter but there will still be some users who would want to use their exisitng prometheus. Irrespective
+  of this solution, we should definitely try to be light on linkerd-prometheus and also provide as many knobs for
+  configuration making it easy to manage. This could be addressed separately and [rfc/21](https://github.com/linkerd/rfc/pull/21) has some similarities.
 - Istio's [Bring your own Prometheus example](https://istiobyexample.dev/prometheus/). A similar helm
 based sub-chart model is used but this was with Mixer v1.
 - We already have docs for [exporting metrics](https://linkerd.io/2/tasks/exporting-metrics/).

--- a/design/0003-byop.md
+++ b/design/0003-byop.md
@@ -76,12 +76,18 @@ prometheus:
   enabled: true
   name: linkerd-prometheus
   image:
+  args:
+  # - log.format: json
   global:
     <global-prom-config> https://prometheus.io/docs/prometheus/latest/configuration/configuration/#configuration-file
   remote-write:
     <remote-write-config> https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write
-  alerts:
-    <alert-manager-config> https://prometheus.io/docs/prometheus/latest/configuration/configuration/#alertmanager_config 
+  alertManagers:
+    <alert-manager-config> https://prometheus.io/docs/prometheus/latest/configuration/configuration/#alertmanager_config
+  configMapMounts:
+  # - name: alerting-rules
+  #   subPath: alerting_rules.yml
+  #   configMap: linkerd-prometheus-rules
 ```
 
 All the current default configuration will be moved to `values.yaml` in the

--- a/design/0003-byop.md
+++ b/design/0003-byop.md
@@ -10,30 +10,37 @@
 
 [summary]: #summary
 
-This RFC aims to move prometheus as an add-on i.e not mandated
-but adviced. This includes changes to the linkerd-prometheus manifests to make it as a add-on and allowing more configuration (more on this later),
-along with documentation and tooling to use existing prometheus installation.
+This RFC aims to move prometheus as an add-on i.e not mandated but advised.
+This includes moving the linkerd-prometheus manifests as a sub-chart and
+allowing more configuration (more on this later), along with documentation
+and tooling to use Linkerd with an existing prometheus installation.
 
 # Problem Statement
 
 [problem-statement]: #problem-statement
 
-Lots of users already have a exisiting prometheus installation in their cluster and don't like managing
-another prometheus instance especially because they could be resource intensive and painful. They usually
-have a prometheus installation paired up with a long term monitroing solutions like Cortex,InfluxDB, or third party
-solutions like Grafana Cloud, etc.
-In those cases prometheus is just a temporary component, that keeps pushing metrics into their long term solution, making users want to re-use their exisitng prometheus.
+Lots of users already have a exisiting prometheus installation in their
+cluster and don't like managing another prometheus instance especially
+because they could be resource intensive and painful. They usually
+have a prometheus installation paired up with a long term monitroing
+solutions like Cortex,InfluxDB, or third party solutions like Grafana
+Cloud, etc. In those cases prometheus is just a temporary component, that
+keeps pushing metrics into their long term solution, making users want to
+re-use their exisitng prometheus.
 
-The following are the list of problems:
+The following are the list of problems that we plan to solve:
 
 - Hard requirement of linkerd-prometheus.
 
-- Configuring the current linkerd-prometheus for remote-writes, etc is hard, because the cm is overriden after upgrades, etc.
+- Configuring the current linkerd-prometheus for remote-writes, etc is
+hard, because the prometheus configmap is overridden after upgrades.
 
-- Not enough documentation for bringing your own prometheus case.
+- Not enough documentation and tooling for bringing your own prometheus
+use-case.
 
-Once the RFC is implemented, Apart from the default prometheus enabled installation Users should be
-able to use their exising prometheus instance, to also scrape metrics from the proxy
+Once the RFC is implemented, Users should not only be able to use their
+exisiting prometheus, but configuration of the linkerd-prometheus for
+remote-writes, etc should also be easy.
 
 # Design proposal
 
@@ -41,21 +48,25 @@ able to use their exising prometheus instance, to also scrape metrics from the p
 
 ## Prometheus as an Add-On
 
-By moving Prometheus as an add-on, We can make it as an optional component that can be used both through Helm and Linkerd CLI.
-The add-on model would well with upgrades, etc as per [#3955](https://github.com/linkerd/linkerd2/pull/3955). This is done by
-moving the prometheus components into a separate sub-chart in the linkerd repo
-and updating the code. The same health checks are also expected, but as a separate
-check Category, which would be transient i.e runs only when it recognises
-that the add-on is enabled.
+By moving Prometheus as an add-on, We can make it as an optional component
+that can be used both through Helm and Linkerd CLI. The add-on model would
+well with upgrades, etc as per [#3955](https://github.com/linkerd/linkerd2/pull/3955).
+This is done by moving the prometheus components into a separate sub-chart
+in the linkerd repo and updating the code. The same health checks are also
+expected, but as a separate check Category, which would be transient i.e
+runs only when it recognises that the add-on is enabled.
 
 By default, the prometheus add-on will be **enabled**.
 
 This also provides a single place of configuration for all things related to
-linkerd-prometheus. Though we are making linkerd-prometheus optional but having it is great for Linkerd and external users, for reasons like separation of
-concerns, etc. By allowing the `remote-write`, `alerts`, etc configuration in the
-linkerd-prometheus, we would decrease the need/want for external users to tie their existing prometheus to Linkerd,
+linkerd-prometheus. Though we are making linkerd-prometheus optional but
+having it is great for Linkerd and external users, for reasons like
+separation of concerns, etc. By allowing the `remote-write`, `alerts`, etc
+configuration in the linkerd-prometheus, we would decrease the need/want
+for external users to tie their existing prometheus to Linkerd,
 as it would be even easier for them to configure `remote-write`, etc
-configuration from their exisiting prometheus to the linkerd-prometheus right from the start.
+configuration from their exisiting prometheus to the linkerd-prometheus
+right from the start.
 
 The following default prometheus configuration is planned:
 
@@ -73,17 +84,24 @@ prometheus:
     <alert-manager-config> https://prometheus.io/docs/prometheus/latest/configuration/configuration/#alertmanager_config 
 ```
 
-All the current default configuration will be moved to `values.yaml` in the above format, allowing users to override this by using Helm or `--addon-config` through CLI.
+All the current default configuration will be moved to `values.yaml` in the
+above format, allowing users to override this by using Helm or  
+`--addon-config` through CLI.
 
 ## Using Exisiting Prometheus
 
-First, Documentation will be provided at `linkerd.io` to guide users on adding
-the `scrape-configs` required, to get the metrics from linkerd proxies, control plane components, etc. This can be found [here](https://github.com/linkerd/linkerd2/blob/master/charts/linkerd2/templates/prometheus.yaml#L26)
+First, Documentation will be provided at `linkerd.io` to guide users on
+adding the `scrape-configs` required, to get the metrics from linkerd
+proxies, control plane components, etc. This can be found
+[here](https://github.com/linkerd/linkerd2/blob/master/charts/linkerd2/templates/prometheus.yaml#L26)
 
-Once this is done, Users should be able to see golden metrics, etc in their exisiting prometheus instance.
-The `prometheus.url` field helps users in configuring Linkerd components i.e `public-api`,etc that needs prometheus access to the exisiting prometheus installation.
+Once this is done, Users should be able to see golden metrics, etc in their
+exisiting prometheus instance. The `prometheus.url` field helps users in
+configuring Linkerd components i.e `public-api`,etc that needs prometheus
+access to the exisiting prometheus installation.
 
 Flag interactions are defined below:
+
 | `prometheus.enabled` | `prometheus.url`              | Result                                                                                                                                                                                                                                           |
 |---------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | true    | ""               | Install linkerd-prometheus, and configure control-plane components to use it.                                                                                                                                                                    |
@@ -94,20 +112,25 @@ Flag interactions are defined below:
 ### Linkerd Check Tooling
 
 When users get their own Prometheus, It would be really great to have
-some tooling that allows users to check if `scrape-configs` are configured correctly and prometheus is able to get metrics.
+some tooling that allows users to check if `scrape-configs` are configured
+correctly and prometheus is able to get metrics.
 
-`--prometheus` flag can be added to linkerd check to run these tests. The following tests are planned:
+`--prometheus` flag can be added to linkerd check to run these tests.
+The following tests are planned:
 
 - Check if the required scrape-configs are present in proemetheus cm.
-( It should be noted that, the prometheus could be present in an different namespace, etc)
+( It should be noted that, the prometheus could be present in an differents
+namespace, etc)
 
-- Check if the common metrics are queriable in prometheus, by using the end-point i.e `prometheus.url` from the `linkerd-values` cm.
+- Check if the common metrics are queriable in prometheus, by using the
+end-point i.e `prometheus.url` from the `linkerd-values` cm.
 
 # Prior art
 
 [prior-art]: #prior-art
 
-- We already have docs for [exporting metrics](https://linkerd.io/2/tasks/exporting-metrics/). We could update those docs, with remote-write, etc.
+- We already have docs for [exporting metrics](https://linkerd.io/2/tasks/exporting-metrics/).
+We could update those docs, with remote-write, etc.
 
 # Unresolved questions
 
@@ -115,13 +138,21 @@ some tooling that allows users to check if `scrape-configs` are configured corre
 
 - Should we support all prometheus configs in `linkerd-prometheus`?
 
-- How do we keep track of metrics that the proxies expose, to have consistent check tooling?
+- How do we keep track of metrics that the proxies expose, to have 
+consistent check tooling?
 
-- Most third party storage solutions have some auth mechanisms, should we allow that? IMO, we shouldn't as they can have a proxy, etc for cases like that.
+- Most third party storage solutions have some auth mechanisms, should we
+allow that? IMO, we shouldn't as they can have a proxy, etc for cases like
+that.
 
 # Future possibilities
 
 [future-possibilities]: #future-possibilities
 
-In this proposal, we separate the query path with the linkerd-promethues, Thus allowing users to use any third party long term storage solution that follow the prometheus Query API to power Dashboards and CLI. 
-Also, The same `bring your own prometheus` document can be re-used for solutions like [grafana cloud agent](https://grafana.com/blog/2020/03/18/introducing-grafana-cloud-agent-a-remote_write-focused-prometheus-agent-that-can-save-40-on-memory-usage/) that follow the same prometheus scrape-config
+In this proposal, we separate the query path with the linkerd-promethues,
+Thus allowing users to use any third party long term storage solution that
+follow the prometheus Query API to power Dashboards and CLI.
+
+Also, The same `bring your own prometheus` document can be re-used for
+solutions like [grafana cloud agent](https://grafana.com/blog/2020/03/18/introducing-grafana-cloud-agent-a-remote_write-focused-prometheus-agent-that-can-save-40-on-memory-usage/)
+that follow the same prometheus scrape-config.

--- a/design/0003-byop.md
+++ b/design/0003-byop.md
@@ -102,7 +102,7 @@ configuring Linkerd components i.e `public-api`,etc that needs prometheus
 access to the exisiting prometheus installation.
 
 `prometheusUrl` is present in `.Values.global` instead of `.Values.prometheus.` to allow this field to
-be accessible by other addOn components like `grafana`, etc. `linkerd-values` Configmap will also be updated to
+be accessible by other addOn components like `grafana`, etc. `linkerd-config-addons` Configmap will also be updated to
 store the same.
 
 Flag interactions are defined below:
@@ -133,7 +133,7 @@ some tooling that allows users to check if prometheus is able to get the metrics
 
 prometheus checks will be added to the default Linkerd health checks, which would check
 if the relevant metrics are present in prometheus by querying, and warn the users about the same. User's
-don't have to supply the `prometheusUrl` as we can access the same from `linkerd-values` Configmap.
+don't have to supply the `prometheusUrl` as we can access the same from `linkerd-config-addons` Configmap.
 
 ### Prior art
 

--- a/design/0003-byop.md
+++ b/design/0003-byop.md
@@ -94,6 +94,9 @@ First, Documentation will be provided at `linkerd.io` to guide users on
 adding the `scrape-configs` required, to get the metrics from linkerd
 proxies, control plane components, etc. This can be found
 [here](https://github.com/linkerd/linkerd2/blob/master/charts/linkerd2/templates/prometheus.yaml#L26).
+Additional documentation on the storage requirements for Linkerd metrics
+in prometheus can also be provided around existing installations with
+longer retention times, scrape interval changes, etc.
 This can also be automated like we already do with Linkerd CLI help and args.
 
 Once this is done, Users should be able to see golden metrics, etc in their
@@ -129,11 +132,24 @@ but just log some warning. So, that users can still access things like TAP, Chec
 #### Linkerd CLI Tooling
 
 When users get their own Prometheus, It would be really great to have
-some tooling that allows users to check if prometheus is able to get the metrics.
+some tooling that allows users to check and troubleshoot if there are any
+problems.
 
-prometheus checks will be added to the default Linkerd health checks, which would check
-if the relevant metrics are present in prometheus by querying, and warn the users about the same. User's
+*linkerd check*
+
+Checks can be added to report if the prometheus is configured correctly and is replying to queries.
+
+- Check if the configured prometheus instance is healthy.
+- if the relevant metrics are present in prometheus by querying, and warn the users about the same. User's
 don't have to supply the `prometheusUrl` as we can access the same from `linkerd-config-addons` Configmap.
+- More checks can be added here, if there are some known
+configurations that don't go well with linkerd.
+
+*linkerd prom-config*
+
+A additional command can be provided in the CLI, which outputs the prometheus-config corresponding to that version of linkerd, which would
+have the relevant scrape-configs and default configuration.
+
 
 ### Prior art
 

--- a/design/0003-byop.md
+++ b/design/0003-byop.md
@@ -1,4 +1,5 @@
-- Bring your own Prometheus
+# Bring your own Prometheus
+
 - @pothulapati
 - Start Date: 2020-04-15
 - Target Date: 
@@ -6,7 +7,7 @@
 - Linkerd Issue: [linkerd/linkerd2#3590](https://github.com/linkerd/linkerd2/issues/3590)
 - Reviewers: @grampelberg @alpeb @siggy
 
-# Summary
+## Summary
 
 [summary]: #summary
 
@@ -15,7 +16,7 @@ This includes moving the linkerd-prometheus manifests as a sub-chart and
 allowing more configuration (more on this later), along with documentation
 and tooling to use Linkerd with an existing prometheus installation.
 
-# Problem Statement
+## Problem Statement (Step 1)
 
 [problem-statement]: #problem-statement
 
@@ -42,11 +43,11 @@ Once the RFC is implemented, Users should not only be able to use their
 exisiting prometheus, but configuration of the linkerd-prometheus for
 remote-writes, etc should also be easy.
 
-# Design proposal
+## Design proposal (Step 2)
 
 [design-proposal]: #design-proposal
 
-## Prometheus as an Add-On
+### Prometheus as an Add-On
 
 By moving Prometheus as an add-on, We can make it as an optional component
 that can be used both through Helm and Linkerd CLI. The add-on model would
@@ -88,7 +89,7 @@ All the current default configuration will be moved to `values.yaml` in the
 above format, allowing users to override this by using Helm or  
 `--addon-config` through CLI.
 
-## Using Exisiting Prometheus
+### Using Exisiting Prometheus
 
 First, Documentation will be provided at `linkerd.io` to guide users on
 adding the `scrape-configs` required, to get the metrics from linkerd
@@ -110,7 +111,7 @@ Flag interactions are defined below:
 | true    | "prometheus.xyz" | Install linkerd-prometheus, but stil configure control plane to use different url, useful when linkerd-prometheus is configured to remote-write into long term storage solution at url, Thus  powering dashboard and CLI through long term storage. |
 | false   | ""               | No linkerd-prometheus, and no URL to power dashboards. (Should we even allow this?)                                                                                                                                                              |
 
-### User Expereince
+#### User Expereince
 
 Currently, `public-api`, `grafana` and `heartbeat` are the only three
 components which are configured with a `prometheus-url` parameter,
@@ -119,7 +120,7 @@ This allows us to swap prometheus without breaking any exisiting linkerd
 tooling. Though it is expected that the `scrape-config` is configured
 correctly, when this path is choosen.
 
-### Linkerd CLI Tooling
+#### Linkerd CLI Tooling
 
 When users get their own Prometheus, It would be really great to have
 some tooling that allows users to check if `scrape-configs` are configured
@@ -138,14 +139,14 @@ maintain the current scrape-config in the CLI, and when user passes the
 name and namespace of the prometheus configmap. We can get it, merge it with
 the latest scrape-config and output allowing the user to apply it.
 
-# Prior art
+### Prior art
 
 [prior-art]: #prior-art
 
 - We already have docs for [exporting metrics](https://linkerd.io/2/tasks/exporting-metrics/).
 We could update those docs, with remote-write, etc.
 
-# Unresolved questions
+### Unresolved questions
 
 [unresolved-questions]: #unresolved-questions
 
@@ -163,7 +164,7 @@ plan on providing documentation.
 allow that? IMO, we shouldn't focus on this in v1 but as folks start to call
 out we can consider updating to handle that use case.
 
-# Future possibilities
+### Future possibilities
 
 [future-possibilities]: #future-possibilities
 

--- a/design/0003-byop.md
+++ b/design/0003-byop.md
@@ -1,0 +1,127 @@
+- Bring your own Prometheus
+- @pothulapati
+- Start Date: 2020-04-15
+- Target Date: 
+- RFC PR: [linkerd/rfc#0000](https://github.com/linkerd/rfc/pull/0000)
+- Linkerd Issue: [linkerd/linkerd2#3590](https://github.com/linkerd/linkerd2/issues/3590)
+- Reviewers: @grampelberg @alpeb @siggy
+
+# Summary
+
+[summary]: #summary
+
+This RFC aims to move prometheus as an add-on i.e not mandated
+but adviced. This includes changes to the linkerd-prometheus manifests to make it as a add-on and allowing more configuration (more on this later),
+along with documentation and tooling to use existing prometheus installation.
+
+# Problem Statement
+
+[problem-statement]: #problem-statement
+
+Lots of users already have a exisiting prometheus installation in their cluster and don't like managing
+another prometheus instance especially because they could be resource intensive and painful. They usually
+have a prometheus installation paired up with a long term monitroing solutions like Cortex,InfluxDB, or third party
+solutions like Grafana Cloud, etc.
+In those cases prometheus is just a temporary component, that keeps pushing metrics into their long term solution, making users want to re-use their exisitng prometheus.
+
+The following are the list of problems:
+
+- Hard requirement of linkerd-prometheus.
+
+- Configuring the current linkerd-prometheus for remote-writes, etc is hard, because the cm is overriden after upgrades, etc.
+
+- Not enough documentation for bringing your own prometheus case.
+
+Once the RFC is implemented, Apart from the default prometheus enabled installation Users should be
+able to use their exising prometheus instance, to also scrape metrics from the proxy
+
+# Design proposal
+
+[design-proposal]: #design-proposal
+
+## Prometheus as an Add-On
+
+By moving Prometheus as an add-on, We can make it as an optional component that can be used both through Helm and Linkerd CLI.
+The add-on model would well with upgrades, etc as per [#3955](https://github.com/linkerd/linkerd2/pull/3955). This is done by
+moving the prometheus components into a separate sub-chart in the linkerd repo
+and updating the code. The same health checks are also expected, but as a separate
+check Category, which would be transient i.e runs only when it recognises
+that the add-on is enabled.
+
+By default, the prometheus add-on will be **enabled**.
+
+This also provides a single place of configuration for all things related to
+linkerd-prometheus. Though we are making linkerd-prometheus optional but having it is great for Linkerd and external users, for reasons like separation of
+concerns, etc. By allowing the `remote-write`, `alerts`, etc configuration in the
+linkerd-prometheus, we would decrease the need/want for external users to tie their existing prometheus to Linkerd,
+as it would be even easier for them to configure `remote-write`, etc
+configuration from their exisiting prometheus to the linkerd-prometheus right from the start.
+
+The following default prometheus configuration is planned:
+
+```yaml
+prometheus:
+  enabled: true
+  name: linkerd-prometheus
+  url: 
+  image: 
+  global:
+    <global-prom-config> https://prometheus.io/docs/prometheus/latest/configuration/configuration/#configuration-file
+  remote-write:
+    <remote-write-config> https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write
+  alerts:
+    <alert-manager-config> https://prometheus.io/docs/prometheus/latest/configuration/configuration/#alertmanager_config 
+```
+
+All the current default configuration will be moved to `values.yaml` in the above format, allowing users to override this by using Helm or `--addon-config` through CLI.
+
+## Using Exisiting Prometheus
+
+First, Documentation will be provided at `linkerd.io` to guide users on adding
+the `scrape-configs` required, to get the metrics from linkerd proxies, control plane components, etc. This can be found [here](https://github.com/linkerd/linkerd2/blob/master/charts/linkerd2/templates/prometheus.yaml#L26)
+
+Once this is done, Users should be able to see golden metrics, etc in their exisiting prometheus instance.
+The `prometheus.url` field helps users in configuring Linkerd components i.e `public-api`,etc that needs prometheus access to the exisiting prometheus installation.
+
+Flag interactions are defined below:
+| `prometheus.enabled` | `prometheus.url`              | Result                                                                                                                                                                                                                                           |
+|---------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| true    | ""               | Install linkerd-prometheus, and configure control-plane components to use it.                                                                                                                                                                    |
+| false   | "prometheus.xyz" | No linkerd-prometheus, control-plane components will be configured to url                                                                                                                                                                        |
+| true    | "prometheus.xyz" | Install linkerd-prometheus, but stil configure control plane to use different url, useful when linkerd-prometheus is configured to remote-write into long term storage solution at url, Thus  powering dashboard and CLI through long term storage. |
+| false   | ""               | No linkerd-prometheus, and no URL to power dashboards. (Should we even allow this?)                                                                                                                                                              |
+
+### Linkerd Check Tooling
+
+When users get their own Prometheus, It would be really great to have
+some tooling that allows users to check if `scrape-configs` are configured correctly and prometheus is able to get metrics.
+
+`--prometheus` flag can be added to linkerd check to run these tests. The following tests are planned:
+
+- Check if the required scrape-configs are present in proemetheus cm.
+( It should be noted that, the prometheus could be present in an different namespace, etc)
+
+- Check if the common metrics are queriable in prometheus, by using the end-point i.e `prometheus.url` from the `linkerd-values` cm.
+
+# Prior art
+
+[prior-art]: #prior-art
+
+- We already have docs for [exporting metrics](https://linkerd.io/2/tasks/exporting-metrics/). We could update those docs, with remote-write, etc.
+
+# Unresolved questions
+
+[unresolved-questions]: #unresolved-questions
+
+- Should we support all prometheus configs in `linkerd-prometheus`?
+
+- How do we keep track of metrics that the proxies expose, to have consistent check tooling?
+
+- Most third party storage solutions have some auth mechanisms, should we allow that? IMO, we shouldn't as they can have a proxy, etc for cases like that.
+
+# Future possibilities
+
+[future-possibilities]: #future-possibilities
+
+In this proposal, we separate the query path with the linkerd-promethues, Thus allowing users to use any third party long term storage solution that follow the prometheus Query API to power Dashboards and CLI. 
+Also, The same `bring your own prometheus` document can be re-used for solutions like [grafana cloud agent](https://grafana.com/blog/2020/03/18/introducing-grafana-cloud-agent-a-remote_write-focused-prometheus-agent-that-can-save-40-on-memory-usage/) that follow the same prometheus scrape-config

--- a/design/0003-byop.md
+++ b/design/0003-byop.md
@@ -3,7 +3,7 @@
 - @pothulapati
 - Start Date: 2020-04-15
 - Target Date: 
-- RFC PR: [linkerd/rfc#0000](https://github.com/linkerd/rfc/pull/0000)
+- RFC PR: [linkerd/rfc#16](https://github.com/linkerd/rfc/pull/16)
 - Linkerd Issue: [linkerd/linkerd2#3590](https://github.com/linkerd/linkerd2/issues/3590)
 - Reviewers: @grampelberg @alpeb @siggy
 

--- a/design/0003-byop.md
+++ b/design/0003-byop.md
@@ -93,7 +93,8 @@ above format, allowing users to override this by using Helm or
 First, Documentation will be provided at `linkerd.io` to guide users on
 adding the `scrape-configs` required, to get the metrics from linkerd
 proxies, control plane components, etc. This can be found
-[here](https://github.com/linkerd/linkerd2/blob/master/charts/linkerd2/templates/prometheus.yaml#L26)
+[here](https://github.com/linkerd/linkerd2/blob/master/charts/linkerd2/templates/prometheus.yaml#L26).
+This can also be automated like we already do with Linkerd CLI help and args.
 
 Once this is done, Users should be able to see golden metrics, etc in their
 exisiting prometheus instance. The `prometheus.url` field helps users in
@@ -109,7 +110,16 @@ Flag interactions are defined below:
 | true    | "prometheus.xyz" | Install linkerd-prometheus, but stil configure control plane to use different url, useful when linkerd-prometheus is configured to remote-write into long term storage solution at url, Thus  powering dashboard and CLI through long term storage. |
 | false   | ""               | No linkerd-prometheus, and no URL to power dashboards. (Should we even allow this?)                                                                                                                                                              |
 
-### Linkerd Check Tooling
+### User Expereince
+
+Currently, `public-api`, `grafana` and `heartbeat` are the only three
+components which are configured with a `prometheus-url` parameter,
+All the Dashboards and CLI are powered through the `public-api`.
+This allows us to swap prometheus without breaking any exisiting linkerd
+tooling. Though it is expected that the `scrape-config` is configured
+correctly, when this path is choosen.
+
+### Linkerd CLI Tooling
 
 When users get their own Prometheus, It would be really great to have
 some tooling that allows users to check if `scrape-configs` are configured
@@ -119,11 +129,14 @@ correctly and prometheus is able to get metrics.
 The following tests are planned:
 
 - Check if the required scrape-configs are present in proemetheus cm.
-( It should be noted that, the prometheus could be present in an differents
-namespace, etc)
+( It should be noted that, the prometheus could be present in a different
+namespace, etc). So, It would be ideal to have users pass the name and
+namespace of the configmap.
 
-- Check if the common metrics are queriable in prometheus, by using the
-end-point i.e `prometheus.url` from the `linkerd-values` cm.
+- A command to update the configmap to the current scrape-config. We can
+maintain the current scrape-config in the CLI, and when user passes the
+name and namespace of the prometheus configmap. We can get it, merge it with
+the latest scrape-config and output allowing the user to apply it.
 
 # Prior art
 
@@ -138,12 +151,17 @@ We could update those docs, with remote-write, etc.
 
 - Should we support all prometheus configs in `linkerd-prometheus`?
 
-- How do we keep track of metrics that the proxies expose, to have 
+- How do we keep track of metrics that the proxies expose, to have
 consistent check tooling?
 
+- A CLI command to update a prometheus configmap with the current linkerd's
+scrape config is definitely feasible, but will it be useful? as we definitely
+plan on providing documentation.
+
+
 - Most third party storage solutions have some auth mechanisms, should we
-allow that? IMO, we shouldn't as they can have a proxy, etc for cases like
-that.
+allow that? IMO, we shouldn't focus on this in v1 but as folks start to call
+out we can consider updating to handle that use case.
 
 # Future possibilities
 

--- a/design/0003-byop.md
+++ b/design/0003-byop.md
@@ -75,8 +75,7 @@ The following default prometheus configuration is planned:
 prometheus:
   enabled: true
   name: linkerd-prometheus
-  url: 
-  image: 
+  image:
   global:
     <global-prom-config> https://prometheus.io/docs/prometheus/latest/configuration/configuration/#configuration-file
   remote-write:
@@ -98,13 +97,17 @@ proxies, control plane components, etc. This can be found
 This can also be automated like we already do with Linkerd CLI help and args.
 
 Once this is done, Users should be able to see golden metrics, etc in their
-exisiting prometheus instance. The `prometheus.url` field helps users in
+exisiting prometheus instance. The `.Values.global.prometheusUrl` field helps users in
 configuring Linkerd components i.e `public-api`,etc that needs prometheus
 access to the exisiting prometheus installation.
 
+`prometheusUrl` is present in `.Values.global` instead of `.Values.prometheus.` to allow this field to
+be accessible by other addOn components like `grafana`, etc. `linkerd-values` Configmap will also be updated to
+store the same.
+
 Flag interactions are defined below:
 
-| `prometheus.enabled` | `prometheus.url`              | Result                                                                                                                                                                                                                                           |
+| `prometheus.enabled` | `global.prometheusUrl`              | Result                                                                                                                                                                                                                                           |
 |---------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | true    | ""               | Install linkerd-prometheus, and configure control-plane components to use it.                                                                                                                                                                    |
 | false   | "prometheus.xyz" | No linkerd-prometheus, control-plane components will be configured to url                                                                                                                                                                        |
@@ -120,29 +123,27 @@ This allows us to swap prometheus without breaking any exisiting linkerd
 tooling. Though it is expected that the `scrape-config` is configured
 correctly, when this path is choosen.
 
+If `prometheus-url` is not accessible, components like `public-api` should not fail
+but just log some warning. So, that users can still access things like TAP, Checks, etc through the dashboard and CLI.
+
 #### Linkerd CLI Tooling
 
 When users get their own Prometheus, It would be really great to have
-some tooling that allows users to check if `scrape-configs` are configured
-correctly and prometheus is able to get metrics.
+some tooling that allows users to check if prometheus is able to get the metrics.
 
-`--prometheus` flag can be added to linkerd check to run these tests.
-The following tests are planned:
-
-- Check if the required scrape-configs are present in proemetheus cm.
-( It should be noted that, the prometheus could be present in a different
-namespace, etc). So, It would be ideal to have users pass the name and
-namespace of the configmap.
-
-- A command to update the configmap to the current scrape-config. We can
-maintain the current scrape-config in the CLI, and when user passes the
-name and namespace of the prometheus configmap. We can get it, merge it with
-the latest scrape-config and output allowing the user to apply it.
+prometheus checks will be added to the default Linkerd health checks, which would check
+if the relevant metrics are present in prometheus by querying, and warn the users about the same. User's
+don't have to supply the `prometheusUrl` as we can access the same from `linkerd-values` Configmap.
 
 ### Prior art
 
 [prior-art]: #prior-art
 
+- [Prometheus  Operator](https://github.com/coreos/prometheus-operator) is a interesting tool,
+ which can remove the problem of maintaining configuration for upgrades, etc from Linkerd, 
+ but comes with it's own controller and CRD's.
+- Istio's [Bring your own Prometheus example](https://istiobyexample.dev/prometheus/). A similar helm
+based sub-chart model is used but this was with Mixer v1.
 - We already have docs for [exporting metrics](https://linkerd.io/2/tasks/exporting-metrics/).
 We could update those docs, with remote-write, etc.
 
@@ -155,14 +156,12 @@ We could update those docs, with remote-write, etc.
 - How do we keep track of metrics that the proxies expose, to have
 consistent check tooling?
 
-- A CLI command to update a prometheus configmap with the current linkerd's
-scrape config is definitely feasible, but will it be useful? as we definitely
-plan on providing documentation.
-
-
 - Most third party storage solutions have some auth mechanisms, should we
 allow that? IMO, we shouldn't focus on this in v1 but as folks start to call
 out we can consider updating to handle that use case.
+
+- Should we separate out each induvidual fields of `proemtheus` i.e `remoteWrite`, etc
+into separate configmaps?
 
 ### Future possibilities
 


### PR DESCRIPTION
Rendered: https://github.com/Pothulapati/rfc/blob/prom/design/0003-byop.md

# Bring your own prometheus

[summary]: #summary

This RFC aims to move prometheus as an add-on i.e not mandated but advised.
This includes moving the linkerd-prometheus manifests as a sub-chart and
allowing more configuration (more on this later), along with documentation
and tooling to use Linkerd with an existing prometheus installation.

# Problem Statement

[problem-statement]: #problem-statement

Lots of users already have a exisiting prometheus installation in their
cluster and don't like managing another prometheus instance especially
because they could be resource intensive and painful. They usually
have a prometheus installation paired up with a long term monitroing
solutions like Cortex,InfluxDB, or third party solutions like Grafana
Cloud, etc. In those cases prometheus is just a temporary component, that
keeps pushing metrics into their long term solution, making users want to
re-use their exisitng prometheus.

The following are the list of problems that we plan to solve:

- Hard requirement of linkerd-prometheus.

- Configuring the current linkerd-prometheus for remote-writes, etc is
hard, because the prometheus configmap is overridden after upgrades.

- Not enough documentation and tooling for bringing your own prometheus
use-case.

Once the RFC is implemented, Users should not only be able to use their
exisiting prometheus, but configuration of the linkerd-prometheus for
remote-writes, etc should also be easy.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>